### PR TITLE
Switch to using a new API for counting tags

### DIFF
--- a/controllers/stats-pre-renderer.js
+++ b/controllers/stats-pre-renderer.js
@@ -16,13 +16,13 @@ const renderer = {
       return;
     }
 
-    // Prepare fetching all statistics we need.
-    let motiftagsWeek = kbhStatsApi.motifTags('week');
-    let geotagsWeek = kbhStatsApi.geotags('week');
-    // @TODO Temporarily disabling totals while we wait for a more performant
-    // solution with a new API-call. See KB-3.
-    let motiftagsTotal = Promise.resolve([]);
-    let geotagsTotal = Promise.resolve([]);
+    // Prepare promises for all statistics we need.
+    let motifTagsCountWeek = kbhStatsApi.motifTagsCount('week');
+    let motifTagsCountAll = kbhStatsApi.motifTagsCount('all');
+    let geoTagsCountWeek = kbhStatsApi.geoTagsCount('week');
+    let geoTagsCountAll = kbhStatsApi.geoTagsCount('all');
+    let assetTagsCountWeek = kbhStatsApi.assetTagsCount('week');
+    let assetTagsCountAll = kbhStatsApi.assetTagsCount('all');
     let usersWeek = kbhStatsApi.allUsersPoints('week');
     let usersTotal = kbhStatsApi.allUsersPoints('all', 25);
 
@@ -93,17 +93,21 @@ const renderer = {
       usersWeek = await usersWeek;
       usersTotal = await usersTotal;
       [
-        motiftagsWeek,
-        geotagsWeek,
-        motiftagsTotal,
-        geotagsTotal,
+        motifTagsCountWeek,
+        motifTagsCountAll,
+        geoTagsCountWeek,
+        geoTagsCountAll,
+        assetTagsCountWeek,
+        assetTagsCountAll,
         usersWeek,
         usersTotal
       ] =  [
-        await motiftagsWeek,
-        await geotagsWeek,
-        await motiftagsTotal,
-        await geotagsTotal,
+        await motifTagsCountWeek,
+        await motifTagsCountAll,
+        await geoTagsCountWeek,
+        await geoTagsCountAll,
+        await assetTagsCountWeek,
+        await assetTagsCountAll,
         // We do a double lookup of users, we could improve performance slightly
         // by looking up the union of the id's first, and then do the mapping.
         await mapUsers(usersWeek),
@@ -112,6 +116,7 @@ const renderer = {
     } catch(err) {
       console.warn('Error while gathering user statistics');
       console.warn(err);
+      // Get rid of the placeholder and return.
       pageContent = pageContent.replace(PLACEHOLDER, '');
       next();
       return;
@@ -120,14 +125,14 @@ const renderer = {
     // We got all the data we needed, now prepare data for the template.
     const stats = {
       'week': {
-        'geotags': geotagsWeek.length,
-        'motiftagged': _.uniqBy(motiftagsWeek, 'asset_id').length,
-        'motiftags': motiftagsWeek.length
+        'geotags': geoTagsCountWeek,
+        'motiftagged': assetTagsCountWeek,
+        'motiftags': motifTagsCountWeek
       },
       'total': {
-        'geotags': geotagsTotal.length,
-        'motiftagged': _.uniqBy(motiftagsTotal, 'asset_id').length,
-        'motiftags': motiftagsTotal.length
+        'geotags': geoTagsCountAll,
+        'motiftagged': assetTagsCountAll,
+        'motiftags': motifTagsCountAll
       },
       'leaders': {
         'week': usersWeek,

--- a/services/kbh-billeder-stats-api.js
+++ b/services/kbh-billeder-stats-api.js
@@ -16,7 +16,8 @@ assert.ok(fallbackEmailFrom, 'Fallback email from undefined');
 const responsecache = new NodeCache({stdTTL: cacheTTL, checkperiod: cacheTTLCheck});
 
 // Setup urls for each endpoint.
-const URL_TAGS = baseUrl + '/tags';
+const URL_TAGSCOUNT = baseUrl + '/tags/count';
+const URL_ASSETSCOUNT = baseUrl + '/assets/count';
 const URL_GEOLOCATIONS = baseUrl + '/geolocations';
 const URL_USERS_POINTS = baseUrl + '/users/points';
 const URL_USERS = baseUrl + '/users';
@@ -68,12 +69,40 @@ const kbhStatsApi = {
     }, () => {return []});
   },
 
-  motifTags: function(timespan = 'all') {
-    return this._doGet(URL_TAGS, {'type': 'tag', 'timespan': timespan});
+  // Returns a promise that resolves to the count of tags.
+  motifTagsCount: function(timespan = 'all') {
+    return this
+      ._doGet(URL_TAGSCOUNT, {'type': 'tag', 'timespan': timespan})
+      .then(
+        // Return the count if we got it, if not return 0.
+        (data) => {
+          return data.tags;
+        }, () => { return 0; }
+      );
   },
 
-  geotags: function(timespan = 'all') {
-    return this._doGet(URL_TAGS, {'type': 'geolocation', 'timespan': timespan});
+  // Returns a promise that resolves to the count of geotags.
+  geoTagsCount: function(timespan = 'all') {
+    return this
+      ._doGet(URL_TAGSCOUNT, {'type': 'geolocation', 'timespan': timespan})
+      .then(
+        // Return the count if we got it, if not return 0.
+        (data) => {
+          return data.geolocations;
+        }, () => { return 0; }
+      );
+  },
+
+  // Returns a promise that resolves to the count images that has tags.
+  assetTagsCount: function(timespan = 'all') {
+    return this
+      ._doGet(URL_ASSETSCOUNT, {'type': 'tags', 'timespan': timespan})
+      .then(
+        // Return the count if we got it, if not return 0.
+        (data) => {
+          return data.count;
+        }, () => { return 0; }
+      );
   },
 
   // Store a user-submitted geotag.


### PR DESCRIPTION
Due to performance issue we're switching from a API that gave us data in bulk, to another endpoint that gives us the aggregated result instead.

KB-3