### PR TITLE
Add a title for for heading

### DIFF
--- a/config/layouts/asset.json
+++ b/config/layouts/asset.json
@@ -37,6 +37,7 @@
         }, {
           "title": "Koordinater",
           "type": "map-coordinates",
+          "titleHeading": "Kompasretning",
           "fields": {
             "latitude": "latitude",
             "longitude": "longitude",


### PR DESCRIPTION
Setting the title will enable display of the heading, otherwise it will only
be displayed on the map.

KB-412