### PR TITLE
Frontpage responsive fixes

### DIFF
--- a/app/styles/frontpage.scss
+++ b/app/styles/frontpage.scss
@@ -61,7 +61,8 @@
     .is-mobile & {
       a {
         float: left;
-        width: 160px;
+        width: 50%;
+        padding: 0 20px;
         margin-bottom: 20px;
       }
     }
@@ -106,6 +107,11 @@
 
       @media (min-width: $medium-size) {
         margin: 0 50px;
+      }
+
+      .is-mobile & {
+        width: 100%;
+        margin: 0;
       }
     }
   }

--- a/app/styles/slick.scss
+++ b/app/styles/slick.scss
@@ -8,7 +8,7 @@
   }
   &-button-container {
     position: absolute;
-    width: 100%;
+    width: calc(100% - 30px);
     .is-desktop & {
       top: 105px;
     }


### PR DESCRIPTION
The frontpage had horizontal scrolling on some mobile devices. What is too big for the screen?
![Screenshot from 2020-05-15 16-59-42](https://user-images.githubusercontent.com/8166831/82219099-1db93600-991d-11ea-897a-f45c9fc871fd.png)

### Changes:
- Jumbo component: Logos were a fixed size on mobile. They should be a more responsive size now.
- Gallery component: Slick slider button container was too big. Fixed the size with calc.