### PR TITLE
Fix edge cases in search input

### DIFF
--- a/collections-online/app/scripts-browserify/search/get-parameters.js
+++ b/collections-online/app/scripts-browserify/search/get-parameters.js
@@ -34,6 +34,18 @@ module.exports = function() {
       if(!filter.skipSplit) {
         value = value.split(',');
       }
+
+      // Escape all Lucene special characters, to avoid syntax errors in
+      // Elastic Search query, c.f.
+      // https://lucene.apache.org/core/3_0_3/queryparsersyntax.html#Escaping%20Special%20Characters
+      [
+        '\\+', '\\-', '\&\&', '\\|\\|', '!', '\\(', '\\)', '\\{', '\\}',
+        '\\[', '\\]', '\\^', '"', '~', '\\*', '\\?', '\\:', '\\\\'
+      ].forEach((luceneSpecialCharacter) => {
+        const characterGlobalPattern = new RegExp(luceneSpecialCharacter, 'g');
+        value = value.replace(characterGlobalPattern, ' ');
+      });
+
       filters[field] = value;
     }
     else if (field === 'map') {


### PR DESCRIPTION
The search queries sent to Elastic Search are interpreted as Lucene syntax, which means that some characters will result in undefined behavior. For example, + must be between words, - removes terms, etc etc.
In this commit we start stripping these values so they dont result in unexpected behavior (users cannot be expected to know or understand (or guess that we use) Lucene).
Specifically, we replace them with spaces, so we dont end up
concatenating words that should not be concatenated. E.g. magasin+okay
will result in magasin okay rather than magasinokay.