### PR TITLE
Endless scrolling focus fix

### DIFF
--- a/app/styles/user-contributions.scss
+++ b/app/styles/user-contributions.scss
@@ -72,11 +72,6 @@
     }
   }
 
-  // We have a wrapper around the loader to be able to select it.
-  .loader-wrapper {
-    display: none;
-  }
-
   &__section {
     &-title {
       margin: 15px 0;
@@ -85,7 +80,7 @@
     }
     .is-loading {
       .loader-wrapper {
-        display: block;
+        display: flex;
       }
     }
   }

--- a/app/styles/user-contributions.scss
+++ b/app/styles/user-contributions.scss
@@ -78,7 +78,7 @@
       font-weight: bolder;
       font-size: 1.25rem;
     }
-    .is-loading {
+    &[aria-busy] {
       .loader-wrapper {
         display: flex;
       }

--- a/app/views/includes/profile/user-contributions-item.pug
+++ b/app/views/includes/profile/user-contributions-item.pug
@@ -1,7 +1,7 @@
 - const documentURL = helpers.getDocumentURL(item);
 - const thumbnailURL = helpers.getThumbnailURL(item);
 
-a(href=documentURL target=target).user-contributions__item.col-xs-6.col-sm-6.col-md-3.col-lg-2.col-xl-1
+a(href=documentURL target=target data-id=item.id).user-contributions__item.col-xs-6.col-sm-6.col-md-3.col-lg-2.col-xl-1
     .search-results-item__squared-container
         img(src=thumbnailURL).search-results-item__squared-image.object-fit
     h2.search-results-item__title= helpers.documentTitle(item)

--- a/app/views/includes/profile/user-contributions-section.pug
+++ b/app/views/includes/profile/user-contributions-section.pug
@@ -3,5 +3,3 @@ div(id=section.id).user-contributions__section
     .user-contributions__section-items
         each item in section.items
             include user-contributions-item
-
-

--- a/app/views/includes/profile/user-contributions.pug
+++ b/app/views/includes/profile/user-contributions.pug
@@ -20,8 +20,7 @@ include ../../mixins/loader
         .user-contributions__section-no-contributions Du har ingen bidrag i denne kategori.
         .user-contributions__section-contributions
         .col-xs-12
-            button.btn.btn-primary.btn-lg.load-more.load-more-btn
-                +loader('Vis flere...')
+            button.btn.btn-primary.btn-lg.load-more.load-more-btn= "Vis flere"
 
     .user-contributions__section.user-contributions__section-location(data-section='location')
         .loader-wrapper
@@ -29,5 +28,4 @@ include ../../mixins/loader
         .user-contributions__section-no-contributions Du har ingen bidrag i denne kategori.
         .user-contributions__section-contributions
         .col-xs-12
-            button.btn.btn-primary.btn-lg.load-more.load-more-btn
-                +loader('Vis flere...')
+            button.btn.btn-primary.btn-lg.load-more.load-more-btn= "Vis flere"

--- a/app/views/includes/profile/user-contributions.pug
+++ b/app/views/includes/profile/user-contributions.pug
@@ -15,17 +15,15 @@ include ../../mixins/loader
             h2.user-contributions__header-tab-title Lokationer
             +icon('location')
     .user-contributions__section.user-contributions__section-tag(data-section='tag')
-        .loader-wrapper
-            +loader()
         .user-contributions__section-no-contributions Du har ingen bidrag i denne kategori.
         .user-contributions__section-contributions
         .col-xs-12
+            +loader("Henter flere...")
             button.btn.btn-primary.btn-lg.load-more.load-more-btn= "Vis flere"
 
     .user-contributions__section.user-contributions__section-location(data-section='location')
-        .loader-wrapper
-            +loader()
         .user-contributions__section-no-contributions Du har ingen bidrag i denne kategori.
         .user-contributions__section-contributions
         .col-xs-12
+            +loader("Henter flere...")
             button.btn.btn-primary.btn-lg.load-more.load-more-btn= "Vis flere"

--- a/app/views/includes/profile/user-contributions.pug
+++ b/app/views/includes/profile/user-contributions.pug
@@ -8,12 +8,12 @@ include ../../mixins/loader
         // The data attributes must be in sync with their section counterparts.
         // See profile/index.js
         .user-contributions__header-tabs
-          .user-contributions__header-tab(data-section='tag')
-              h2.user-contributions__header-tab-title Emneord
-              +icon('tag')
-          .user-contributions__header-tab(data-section='location')
-            h2.user-contributions__header-tab-title Lokationer
-            +icon('location')
+            .user-contributions__header-tab(data-section='tag')
+                h2.user-contributions__header-tab-title Emneord
+                +icon('tag')
+            .user-contributions__header-tab(data-section='location')
+                h2.user-contributions__header-tab-title Lokationer
+                +icon('location')
     .user-contributions__section.user-contributions__section-tag(data-section='tag')
         .user-contributions__section-no-contributions Du har ingen bidrag i denne kategori.
         .user-contributions__section-contributions

--- a/collections-online/app/scripts-browserify/search/index.js
+++ b/collections-online/app/scripts-browserify/search/index.js
@@ -223,13 +223,19 @@ function initialize() {
       resultsTotal = response.hits.total;
       loadingResults = false;
 
-      response.hits.hits.forEach(function(hit) {
+      response.hits.hits.forEach(function(hit, i) {
         const item = {
           type: hit._type,
           metadata: hit._source
         };
         const markup = templates.searchResultItem(item);
         $results.append(markup);
+
+        //Focus on the first new element added
+        if(i === 0) {
+          $results.children().last().focus();
+        }
+
         resultsLoaded.push(item);
       });
 

--- a/collections-online/app/scripts-browserify/search/index.js
+++ b/collections-online/app/scripts-browserify/search/index.js
@@ -128,10 +128,8 @@ function initialize() {
       if(updateWidgets) {
         resultsHeader.update(searchParams, resultsTotal);
       }
-      if(indicateLoading) {
-        $('.search-results').removeClass('search-results--loading');
-        $results.removeAttr('aria-busy');
-      }
+      $('.search-results').removeClass('search-results--loading');
+      $results.removeAttr('aria-busy');
     };
 
     // Do search depending on current viewmode.

--- a/collections-online/app/scripts-browserify/search/index.js
+++ b/collections-online/app/scripts-browserify/search/index.js
@@ -127,9 +127,10 @@ function initialize() {
       // Update the results header with the result
       if(updateWidgets) {
         resultsHeader.update(searchParams, resultsTotal);
-        if(indicateLoading) {
-          $('.search-results').removeClass('search-results--loading');
-        }
+      }
+      if(indicateLoading) {
+        $('.search-results').removeClass('search-results--loading');
+        $results.removeAttr('aria-busy');
       }
     };
 
@@ -187,15 +188,11 @@ function initialize() {
         console.trace(error.message);
       });
     } else if (viewMode === 'list') {
-      if (updateWidgets) {
-        // Start updating the results header
-        resultsHeader.update(searchParams, resultsTotal);
-        // Update the results header before the result comes in
-        if(indicateLoading) {
-          $('.search-results').addClass('search-results--loading');
-        }
+      if(indicateLoading) {
+        $('.search-results').addClass('search-results--loading');
+        $results.attr('aria-busy', true);
       }
-      resultsTotal = updateList(searchParams, updateWidgets, resultCallback);
+      updateList(searchParams, updateWidgets, resultCallback);
     }
   }
 
@@ -311,7 +308,7 @@ function initialize() {
         var scrollBottom = scrollTop + $(window).height();
         if(scrollBottom > lastResultOffset.top && !loadingResults) {
           resultsDesired += PAGE_SIZE;
-          update();
+          update(false, true);
         }
       }
     }).scroll();
@@ -343,7 +340,7 @@ function initialize() {
 
       // Using the updateWidgets=true, updates the header as well
       // Using the indicateLoading=false makes sure the UI doesn't blink
-      update(true, false);
+      update(true, true);
     }
   }
 
@@ -356,7 +353,7 @@ function initialize() {
   const searchControllerCallbacks = {
     // Allow the caller to refresh the current search-results.
     refresh: function() {
-      update(true, false);
+      update(true, true);
     },
 
     getCurrentSearchParameters: function (){
@@ -415,7 +412,7 @@ function initialize() {
       }
       // Store changed parameters and trigger a search.
       persistChangedParams(searchParams);
-      update();
+      update(false, true);
     } else if(action === 'remove-filter') {
       if(typeof(filters[field]) === 'object') {
         filters[field] = filters[field].filter(function(v) {
@@ -426,7 +423,7 @@ function initialize() {
       }
       // Store changed parameters and trigger a search.
       persistChangedParams(searchParams);
-      update();
+      update(false, true);
     }
   });
 
@@ -436,7 +433,7 @@ function initialize() {
     searchParams.sorting = sorting;
     // Store changed parameters and trigger a search.
     persistChangedParams(searchParams);
-    update();
+    update(false, true);
   });
 
   // Enabled the load-more button
@@ -527,7 +524,7 @@ function initialize() {
     searchParams.filters.q = queryString;
     // Store changed parameters and trigger a search.
     persistChangedParams(searchParams);
-    update();
+    update(false, true);
   });
 
   // Everything is ready, prepare to show results.
@@ -546,7 +543,7 @@ function initialize() {
     }
     else {
       // No relevant url-parameter and no relevant state, just do a cold update.
-      update();
+      update(false, true);
     }
   }
 }

--- a/collections-online/app/styles/loading.scss
+++ b/collections-online/app/styles/loading.scss
@@ -2,23 +2,41 @@ $size: .7em;
 $small-scale: scaleX(.5) scaleY(.5);
 $one-scale: scaleX(1) scaleY(1);
 
-.loader {
-  animation: loading-dots 1.5s infinite ease-in-out 0s;
-  animation-delay: -.4s;
-  background-color: currentColor;
-  border-radius: 50%;
-  display: inline-block;
-  height: $size;
-  margin-left: .5em;
-  width: $size;
+.centered-loader {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+}
 
-  &.one {
-    animation-delay: -.2s;
+.loader-wrapper {
+  padding: $size;
+  display: none;
+  flex-direction: column-reverse;
+
+  .loader-set {
+    text-align: center;
   }
 
-  &.two {
-    animation-delay: 0s;
-    margin-right: .5em;
+  .loader {
+    animation: loading-dots 1.5s infinite ease-in-out 0s;
+    animation-delay: -.4s;
+    background-color: currentColor;
+    border-radius: 50%;
+    display: inline-block;
+    height: $size;
+    margin-left: .5em;
+    width: $size;
+
+    &.one {
+      animation-delay: -.2s;
+    }
+
+    &.two {
+      animation-delay: 0s;
+      margin-right: .5em;
+    }
   }
 }
 
@@ -37,21 +55,5 @@ $one-scale: scaleX(1) scaleY(1);
 
   100% {
     transform: $small-scale;
-  }
-}
-
-.btn {
-  .loader {
-    display: none;
-  }
-
-  &.loading {
-    .loader {
-      display: inline-block;
-    }
-
-    .text {
-      display: none;
-    }
   }
 }

--- a/collections-online/app/styles/loading.scss
+++ b/collections-online/app/styles/loading.scss
@@ -14,6 +14,7 @@ $one-scale: scaleX(1) scaleY(1);
   padding: $size;
   display: none;
   flex-direction: column-reverse;
+  text-align: center;
 
   .loader-set {
     text-align: center;

--- a/collections-online/app/styles/search-results.scss
+++ b/collections-online/app/styles/search-results.scss
@@ -4,19 +4,17 @@
   }
 
   &--loading {
+    .loader-wrapper {
+      display: flex;
+    }
+
     .search-results-header,
     .search-results-item {
       opacity: .75;
     }
 
-    .search-results-header {
-      &__title--loading {
-        display: inline-block;
-      }
-
-      &__title--loaded {
-        display: none;
-      }
+    #no-results-text {
+      display: none;
     }
   }
 }
@@ -35,10 +33,6 @@
 
   &__title {
     margin: 0;
-
-    &--loading {
-      display: none;
-    }
 
     &--loaded {
       display: inline-block;

--- a/collections-online/app/views/includes/geo-tagging.pug
+++ b/collections-online/app/views/includes/geo-tagging.pug
@@ -15,8 +15,7 @@ include ../mixins/loader
     .geo-tagging__map-buttons
       button.btn.btn-primary(data-action='geo-tagging:stop')
         | Annuller
-      button.btn.btn-primary(data-action='save-geo-tag')
-        +loader('Gem placering')
+      button.btn.btn-primary(data-action='save-geo-tag')= "Gem placering"
       button.btn.btn-primary(data-action='back-to-map')
         | Tilbage til kortvisning
     .geo-tagging__overlay

--- a/collections-online/app/views/includes/search-results-header.pug
+++ b/collections-online/app/views/includes/search-results-header.pug
@@ -3,8 +3,6 @@ include ../mixins/loader
 
 .search-results-header
   h1.search-results-header__title
-    .search-results-header__title--loading
-      +loader()
     .search-results-header__title--loaded
       if isFiltered
         | Filtrering gav

--- a/collections-online/app/views/mixins/loader.pug
+++ b/collections-online/app/views/mixins/loader.pug
@@ -1,6 +1,8 @@
 mixin loader(text)
-  if text
-    span.text #{text}
-  .loader
-  .loader.one
-  .loader.two
+  .loader-wrapper
+    if text
+      span.text #{text}
+    .loader-set
+      .loader
+      .loader.one
+      .loader.two

--- a/collections-online/app/views/search.pug
+++ b/collections-online/app/views/search.pug
@@ -24,9 +24,10 @@ block content
             include includes/no-results-text
             #results.row
               block results
+              .centered-loader
+                +loader("Henter poster...")
             block after-results
-              button.btn.btn-primary.btn-lg.invisible.load-more#load-more-btn
-                +loader('Vis flere...')
+              button.btn.btn-primary.btn-lg.invisible.load-more#load-more-btn= "Vis flere"
     else
       section.container-fluid
         .search-results
@@ -35,9 +36,10 @@ block content
           include includes/no-results-text
           #results.row
             block results
+            .centered-loader
+              +loader("Henter poster...")
           block after-results
-            button.btn.btn-primary.btn-lg.invisible.load-more#load-more-btn
-              +loader('Vis flere...')
+            button.btn.btn-primary.btn-lg.invisible.load-more#load-more-btn= "Vis flere"
   .clearfix
 
   if(config.features.scrollToTop)

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -92,10 +92,8 @@ users.fetchUserContributions = async (req, res, next) => {
           const contribution = doc._source;
           // Add in the contribution time from our original fetch of
           // contributions.
-          contribution.contribution_time = _.find(contributions,
-            contribution => {
-              return contribution.asset_id === doc._id;
-            }).updated;
+          const original = contributions.find(c => c.asset_id === doc._id);
+          contribution.contribution_time = original.updated;
           contribution.formatted_date = helpers.formatDate(contribution.contribution_time);
           return contribution;
         });


### PR DESCRIPTION
Fixes accessibility of endless scrolling in the profile view (listing contributions) and the search result view:

- using `aria-busy` to indicate loading programatically
- focusing first newly loaded element when loading concludes after pressing "load more" button
- added text to the loading indicator, so it becomes semantically meaningful/provides a similar experience for visual browsers and screen readers alike