### PR TITLE
Feature working cookiebot

### DIFF
--- a/app/scripts-browserify/analytics.js
+++ b/app/scripts-browserify/analytics.js
@@ -1,5 +1,5 @@
 $(function() {
-  if(ga) {
+  if(ga && window.Cookiebot && window.Cookiebot.consent.statistics) {
     $('[data-content="asset-download"] .btn').on('click', function(){
       var href = $(this).attr('href');
       var hrefArray = href.split("/");

--- a/app/views/frontpage.pug
+++ b/app/views/frontpage.pug
@@ -62,7 +62,7 @@ block content-bottom
 
 append javascript
   - baseURL = 'http://' + (req.get('x-forwarded-host') || req.get('host')) + '/'
-  script(type="application/ld+json").
+  script(type='application/ld+json').
     {
       "@context": "http://schema.org",
       "@type": "WebSite",

--- a/app/views/index.pug
+++ b/app/views/index.pug
@@ -1,3 +1,3 @@
 extends index
 append javascript
-    script(src='../scripts-static/ol.js')
+    script(src='../scripts-static/ol.js' data-cookieconsent='ignore')

--- a/collections-online/app/views/includes/head.pug
+++ b/collections-online/app/views/includes/head.pug
@@ -1,4 +1,4 @@
-script(id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e079a717-1a3f-4fd9-8677-b42d07ce6446" data-blockingmode="auto" type="text/javascript")
+script(id='Cookiebot' src='https://consent.cookiebot.com/uc.js' data-cbid='e079a717-1a3f-4fd9-8677-b42d07ce6446' data-blockingmode='auto' type='text/javascript')
 meta(charset='utf-8')
 meta(http-equiv='X-UA-Compatible', content='IE=edge')
 meta(name='viewport', content='width=device-width, initial-scale=1, maximum-scale=1')

--- a/collections-online/app/views/includes/scripts.pug
+++ b/collections-online/app/views/includes/scripts.pug
@@ -2,4 +2,4 @@ if config.features.enableGoogleTranslate
   //- Needs to be before main.js
   include ./translate
 
-script(src='/scripts/main.js')
+script(src='/scripts/main.js' data-cookieconsent="ignore")

--- a/collections-online/app/views/includes/scripts.pug
+++ b/collections-online/app/views/includes/scripts.pug
@@ -2,4 +2,4 @@ if config.features.enableGoogleTranslate
   //- Needs to be before main.js
   include ./translate
 
-script(src='/scripts/main.js' data-cookieconsent="ignore")
+script(src='/scripts/main.js' data-cookieconsent='ignore')


### PR DESCRIPTION
Added ignore tags to every script on frontpage.

Note that the last commit is untested. This is only included to show how a Cookiebot report page could be created.