### PR TITLE
Mobile search page elements should not be absolute.

### DIFF
--- a/collections-online/app/styles/list-view.scss
+++ b/collections-online/app/styles/list-view.scss
@@ -22,7 +22,6 @@
     padding: 0 $spacer-lg;
     width: 100%;
     height: 100vh;
-    position: absolute;
     top: 40px;
     background: white;
     overflow: visible;

--- a/collections-online/app/styles/mobile-filter.scss
+++ b/collections-online/app/styles/mobile-filter.scss
@@ -8,7 +8,7 @@
 #sidebarmobile {
   width: 100%;
   height: calc(100vh - 40px);
-  position: absolute;
+  position: static;
   top: 40px;
   left: 0;
   background: $gray-lighter;


### PR DESCRIPTION
### Description
with the footer now visible on mobile view the other elements should not have position absolute.