### PR TITLE
Accessibility: Keyboard navigation for download overlay

### DIFF
--- a/app/styles/buttons.scss
+++ b/app/styles/buttons.scss
@@ -25,11 +25,14 @@
   @media (pointer:fine) {
     transition: $anim-default;
 
-    &:hover,
-    &:focus {
+    &:hover {
       @include shadow(2);
       transform: translateY(-1px);
       z-index: 1;
+    }
+
+    &:focus {
+      outline: $white solid 1px;
     }
   }
 }

--- a/collections-online/app/scripts-browserify/asset.js
+++ b/collections-online/app/scripts-browserify/asset.js
@@ -55,8 +55,15 @@ const config = require('collections-online/shared/config');
       if (show === true) {
         $el.addClass(OVERLAY_ACTIVE_CLASS);
         $el.addClass(OVERLAY_ANIM_IN_CLASS);
-      } else if (show === false) {
+
+        // Focus first link in the overlay
+        setTimeout(function(){
+          $el.find('.btn:first').focus();
+        }, 50); // wait for the elements to be visible otherwise focus won't happen
+      }
+      else if (show === false) {
         $el.removeClass(OVERLAY_ANIM_IN_CLASS);
+        $(ACTION_ASSET_DOWNLOAD_SHOW).focus();
         setTimeout(function() {
           $el.removeClass(OVERLAY_ACTIVE_CLASS);
         }, 300);

--- a/collections-online/app/views/includes/download-overlay.pug
+++ b/collections-online/app/views/includes/download-overlay.pug
@@ -5,8 +5,9 @@
       each option in helpers.getDownloadOptions(metadata)
         a.btn.btn-primary(href=option.url, target="_blank")
           = option.label
-      .overlay__license
+      .overlay__license.btn
         +displayLicense(metadata)
     else
       h2 Vi beklager
       p Billedet er ophavsretligt beskyttet og kan derfor ikke downloades uden forudgående aftale med fotografen.
+    button.btn.btn-default Luk


### PR DESCRIPTION
## Changes:
- Add keyboard navigation for download overlay.
- Make button focus more visible.

## Screenshots:
![Opera Snapshot_2020-05-30_182712_localhost](https://user-images.githubusercontent.com/8166831/83334012-ebf08980-a2a3-11ea-9e05-42a76faaa93f.png)
![Opera Snapshot_2020-05-30_182732_localhost](https://user-images.githubusercontent.com/8166831/83334013-ed21b680-a2a3-11ea-8f08-7d06d1ada2d1.png)
