### PR TITLE
Better validation for feedback form

### DIFF
--- a/collections-online/app/scripts-browserify/document/feedback.js
+++ b/collections-online/app/scripts-browserify/document/feedback.js
@@ -40,7 +40,6 @@ $(function() {
     }
 
     handleError(errorMessage) {
-      console.warn('msg', errorMessage, this.$errorMessage)
       this.$errorMessage.text(errorMessage);
       this.$feedback.addClass(ERROR_CLASS);
     }

--- a/collections-online/app/scripts-browserify/document/feedback.js
+++ b/collections-online/app/scripts-browserify/document/feedback.js
@@ -6,6 +6,7 @@ const HIDE_EDITING_SELECTOR = '[data-action="feedback:stop"]';
 const SEND_FORM_SELECTOR = '[data-action="feedback:send"]';
 
 const FORM_SELECTOR = '.feedback__form';
+const FORM_ERROR_MESSAGE = '.feedback__error-message';
 const COUNTER_SELECTOR = '.feedback__counter';
 const EDITING_CONTAINER_SELECTOR = '.feedback__container';
 
@@ -20,6 +21,7 @@ $(function() {
       this.$feedback = $feedback;
       this.$container = $feedback.find(EDITING_CONTAINER_SELECTOR);
       this.$form = $feedback.find(FORM_SELECTOR);
+      this.$errorMessage = $feedback.find(FORM_ERROR_MESSAGE);
       this.$counter = $feedback.find(COUNTER_SELECTOR);
       this.$sendButton = $feedback.find(SEND_FORM_SELECTOR);
 
@@ -37,7 +39,9 @@ $(function() {
       this.$feedback.toggleClass(IS_EDITING_CLASS, editing);
     }
 
-    handleError() {
+    handleError(errorMessage) {
+      console.warn('msg', errorMessage, this.$errorMessage)
+      this.$errorMessage.text(errorMessage);
       this.$feedback.addClass(ERROR_CLASS);
     }
 
@@ -49,11 +53,16 @@ $(function() {
     send() {
       const url = location.pathname + '/feedback';
       const message = this.$form.val();
-      this.$sendButton.attr('disabled', true);
-      $.post(url, {message}, () => {}, 'json')
-      .done(() => this.handleSuccess())
-      .fail(() => this.handleError())
-      .always(() => this.$sendButton.attr('disabled', false))
+      if(message) {
+        this.$sendButton.attr('disabled', true);
+        $.post(url, {message}, () => {}, 'json')
+        .done(() => this.handleSuccess())
+        .fail(() => this.handleError('Der skete en fejl. Prøv venligst igen senere.'))
+        .always(() => this.$sendButton.attr('disabled', false))
+      }
+      else {
+        this.handleError('Du kan ikke sende en tom besked.');
+      }
     }
 
     registerListeners() {

--- a/collections-online/app/styles/feedback.scss
+++ b/collections-online/app/styles/feedback.scss
@@ -32,7 +32,7 @@
   }
 
   &__error-message {
-    color: $brand-danger;
+    color: darken($brand-danger, 20%);
     display: none;
   }
 

--- a/collections-online/app/views/includes/feedback.pug
+++ b/collections-online/app/views/includes/feedback.pug
@@ -14,7 +14,6 @@
       button.feedback__btn-form-hide.btn.btn-default(data-action='feedback:stop')
         | Annuller
       span.feedback__error-message
-        | Der skete en fejl. Prøv venligst igen senere.
       span.feedback__counter-container
         span.feedback__counter 0
         |  /


### PR DESCRIPTION
## Changes
- Form should not post if input is an empty string.
- Add error message for empty form.
- Increase contrast on error message to be WCAG AA compatible.