### PR TITLE
Installs newer nginx on docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,21 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     g++ \
     supervisor \
+    curl \
+    gnupg2 \
+    ca-certificates \
+    lsb-release \
+&& rm -rf /var/lib/apt/lists/* # Keeps the image size down
+
+RUN echo "deb http://nginx.org/packages/debian `lsb_release -cs` nginx" \ | tee /etc/apt/sources.list.d/nginx.list
+RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | apt-key add -
+
+RUN apt-get update && apt-get install -y \
     nginx \
 && rm -rf /var/lib/apt/lists/* # Keeps the image size down
 
-COPY . /tmp/
 WORKDIR /tmp/
+COPY . .
 
 # --no-color is needed to prevent strange chars in the CI logs
 # --no-spin is needed to prevent duplicated lines in the CI logs


### PR DESCRIPTION
This adds the official nginx debian mirror, which includes prebuilt nginx 1.18.0, for installation via apt. Luckily this actually worked without needing to update anything else. I worried we might have to update glibc or similar, but the nginx developers are apperently very conservative, which is good. :)

I have not tested this with the full pipeline - but just built the single Dockerfile. Please, someone check out my PR and verify. Also, see screenshot below.

![image](https://user-images.githubusercontent.com/167812/85780776-45be6500-b725-11ea-81e1-3c8d9e5214f8.png)
