### PR TITLE
Accessibility: Increase contrast for dropdown icons

### DIFF
--- a/collections-online/app/styles/filterbar.scss
+++ b/collections-online/app/styles/filterbar.scss
@@ -260,7 +260,7 @@ $heading-adjustment: 2px;
       }
 
       &::after {
-        background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M16.6 8.6L12 13.2 7.4 8.6 6 10l6 6 6-6z' fill='rgba(0,0,0,0.3)'/%3E%3C/svg%3E");
+        background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M16.6 8.6L12 13.2 7.4 8.6 6 10l6 6 6-6z' fill='rgba(0,0,0,0.6)'/%3E%3C/svg%3E");
         background-position: center;
         background-repeat: no-repeat;
         background-size: $spacer-lg;


### PR DESCRIPTION
### Changes:
Decrease the opacity for the SVG dropdown icon to increase contrast.

### Screenshot:
Before:
![image](https://user-images.githubusercontent.com/8166831/86135043-9bf72380-baea-11ea-92b2-898db1210f48.png)

After:
![image](https://user-images.githubusercontent.com/8166831/86134976-85e96300-baea-11ea-8ddc-460fc06b5328.png)