### PR TITLE
Search-items z-index problem

### DIFF
--- a/collections-online/app/styles/filterbar.scss
+++ b/collections-online/app/styles/filterbar.scss
@@ -8,7 +8,7 @@ $heading-adjustment: 2px;
   width: 100%;
   padding: 0 $spacer-layout;
   position: relative;
-  z-index: 1;
+  z-index: 2;
   @media (min-width: $extra-large-size) {
     padding: 0 20px;
   }


### PR DESCRIPTION
### Changes:
Increase z-index on filterbar to prevent overflowing from focused image-cards.

### Screenshots:
#### Before:
![image](https://user-images.githubusercontent.com/8166831/86149807-c356ec00-bafc-11ea-9307-e9abecbd7c31.png)

#### After:
![image](https://user-images.githubusercontent.com/8166831/86149753-b0dcb280-bafc-11ea-9461-5f5fc99d0480.png)
