### PR TITLE
Show tiled zoom button on mobile

### DIFF
--- a/app/views/includes/player-controls.pug
+++ b/app/views/includes/player-controls.pug
@@ -7,7 +7,7 @@ block document__player-controls
   - const getZoomTilesId = helpers.getZoomTilesId(metadata);
 
   if getZoomTilesId
-    a(data-action='toggle-tiled-zoom').hidden-xs.hidden-sm.zoom-btn
+    button(data-action='toggle-tiled-zoom').zoom-btn.btn.btn-transparent.btn-no-shadow
       +icon('zoom-in', 'zoom-in')
       span.zoom-in Zoom
 


### PR DESCRIPTION
I have checked that the functionality works. The tiled-zoom is actually done by clicking the image on mobile, but there is no way of knowing that, unless you try.

Trello: https://trello.com/c/YXUecf9S/40-zoom-knap-mangler-i-mobil-visning