### PR TITLE
Fix horizontal scrolling on mobile (asset page)

### DIFF
--- a/app/styles/geo-tagging.scss
+++ b/app/styles/geo-tagging.scss
@@ -28,18 +28,17 @@ $map-height: 455px;
   }
   &__inner {
     pointer-events: auto;
+    background: white;
+    margin-top: 75px;
+    max-width: 400px;
+    min-height: 300px;
+    padding: $spacer-lg;
+    @include shadow(5);
     .is-mobile & {
       position: static;
       margin-top: 0;
       @include shadow(0);
     }
-    display: inline-block;
-    background: white;
-    margin-top: 75px;
-    width: 400px;
-    min-height: 300px;
-    padding: $spacer-lg;
-    @include shadow(5);
     .btn {
       float: left;
       width: auto;


### PR DESCRIPTION
### Changes:
- Change fixed width to a max-width to avoid horizontal scrolling on mobile devices.
- Clean up CSS a bit.

### Screenshot of problem:
![Screenshot from 2020-07-01 18-24-29](https://user-images.githubusercontent.com/8166831/86268608-bb647e00-bbc8-11ea-99ac-0cb007c01e69.png)
