### PR TITLE
fix visual bug when tagging an asset

### DIFF
--- a/app/styles/motif-tagging.scss
+++ b/app/styles/motif-tagging.scss
@@ -13,6 +13,8 @@
     }
   }
   &__tags {
+    display: flex;
+    flex-wrap: wrap;
     margin-top: $spacer-md;
     .motif-tagging__remove-btn {
       float: right;

--- a/collections-online/app/styles/motif-tagging.scss
+++ b/collections-online/app/styles/motif-tagging.scss
@@ -1,6 +1,6 @@
 .motif-tagging {
   .btn-group {
-    display: inline-block;
+    display: flex;
 
     &:not(:last-child) {
       margin-right: .5rem;


### PR DESCRIPTION
Actually had the same bug in chrome and firefox.

### Screenshot:
#### Before:
![image](https://user-images.githubusercontent.com/8166831/86371920-d2b37200-bc81-11ea-93f6-b65a1c47878d.png)

#### After:
![image](https://user-images.githubusercontent.com/8166831/86371864-bdd6de80-bc81-11ea-8150-0df4a044d437.png)
