### PR TITLE
Bug: Add new location to asset

### DIFF
--- a/app/views/asset.pug
+++ b/app/views/asset.pug
@@ -41,7 +41,7 @@ block document__section-2
                   | Placer billede på kort
                   +icon('pencil')
 
-    section.document__section-2--map(class=(hasLocation ? 'has-location' : 'no-location'))
+    section.document__section-2--map(class=(hasLocation ? 'has-location' : 'hidden'))
       .geo-tagging-mini-map(
         data-has-location=(hasLocation) ? 'true' : 'false'
         data-latitude=location.latitude,


### PR DESCRIPTION
Assets without any location was bugged since the location elements will never show since the class was changed to "hidden". Changed the class in the HTML too and everything works just fine,