### PR TITLE
Adds 302 redirect to was

### DIFF
--- a/configurations/nginx.conf
+++ b/configurations/nginx.conf
@@ -39,6 +39,10 @@ http {
       root /tmp/app;
     }
 
+    location = /was {
+      return 302 https://www.was.digst.dk/kbhbilleder-dk;
+    }
+
     location ~ ^/(scripts|styles|images)/(.*)$ {
       include /etc/nginx/mime.types;
       gzip on;


### PR DESCRIPTION
Jeg har brugt 302 - da en 301 hurtigt giver problemer med browser-caches, når man vil ændre opførslen af adressen.