### PR TITLE
Update gulp-uglify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9284,18 +9284,32 @@
       }
     },
     "gulp-uglify": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-2.1.2.tgz",
-      "integrity": "sha1-bbhbHQ7mPRgFhZK2WGSdZcLsRUE=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.2.tgz",
+      "integrity": "sha512-gk1dhB74AkV2kzqPMQBLA3jPoIAPd/nlNzP2XMDSG8XZrqnlCiDGAqC+rZOumzFvB5zOphlFh6yr3lgcAb/OOg==",
       "requires": {
+        "array-each": "^1.0.1",
+        "extend-shallow": "^3.0.2",
         "gulplog": "^1.0.0",
         "has-gulplog": "^0.1.0",
-        "lodash": "^4.13.1",
+        "isobject": "^3.0.1",
         "make-error-cause": "^1.1.1",
+        "safe-buffer": "^5.1.2",
         "through2": "^2.0.0",
-        "uglify-js": "~2.8.10",
-        "uglify-save-license": "^0.4.1",
+        "uglify-js": "^3.0.5",
         "vinyl-sourcemaps-apply": "^0.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "uglify-js": {
+          "version": "3.13.3",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.3.tgz",
+          "integrity": "sha512-otIc7O9LyxpUcQoXzj2hL4LPWKklO6LJWoJUzNa8A17Xgi4fOeDC8FBDOLHnC/Slo1CQgsZMcM6as0M76BZaig=="
+        }
       }
     },
     "gulp-unique-files": {
@@ -11969,9 +11983,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "make-error-cause": {
       "version": "1.2.2",
@@ -17631,11 +17645,6 @@
           }
         }
       }
-    },
-    "uglify-save-license": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz",
-      "integrity": "sha1-lXJsF8xv0XHDYX479NjYKqjEzOE="
     },
     "uglify-to-browserify": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kbh-billeder",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kbh-billeder",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Configuration/setup for the kbhbilleder.dk webapp built on top of Collections Online",
   "main": "server.js",
   "browserslist": "last 4 versions",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "gulp-sourcemaps": "^1.12.1",
     "gulp-svgmin": "^3.0.0",
     "gulp-svgstore": "^6.1.1",
-    "gulp-uglify": "^2.0.0",
+    "gulp-uglify": "^3.0.2",
     "gulp-unique-files": "^0.2.0",
     "hammerjs": "^2.0.8",
     "iconv": "^3.0.0",


### PR DESCRIPTION
gulp-uglify needed to be updated along with other gulp libs, but we didn't spot it because it (alone!) is only used in production og beta, not in development