### PR TITLE
Align big series search result with images

### DIFF
--- a/app/styles/search-results-item.scss
+++ b/app/styles/search-results-item.scss
@@ -21,6 +21,10 @@
   flex-direction: column;
   padding: 1em 1em 2em;
 
+  /* align first series result box with images in other results */
+  margin-bottom: 15px;
+  border-right: 15px solid white;
+
   a:not(.tag) {
     color: inherit;
     text-decoration: inherit;


### PR DESCRIPTION
Kind of some odd tricks here, but it aligns the big search result's box with the images around it in the way it was designed to.

I would have liked to add horizontal margin to the box instead of this border-trick, but that breaks bootstrap's column system.

![image](https://user-images.githubusercontent.com/859106/114773822-d0815680-9d6f-11eb-88ee-1cfd99e6bba9.png)
