### PR TITLE
Support large series by chunking asset IDs in lookup

### DIFF
--- a/collections-online/lib/express.js
+++ b/collections-online/lib/express.js
@@ -35,7 +35,7 @@ module.exports = function(app) {
   app.use(express.urlencoded({
     extended: true
   }));
-  app.use(express.json());
+  app.use(express.json({limit: 1204 * 1204}));
   app.use(cookieParser());
   // If the config host is sat and the requested host does not match, redirect
   app.use((req, res, next) => {


### PR DESCRIPTION
large series would break elasticsearch. we can chunk the results in smaller lists, which elasticsearch can parse.
this menas that searching inside a series now works even if there are 1000+ assets in it.