### PR TITLE
ensure that filters and sort are on top of the first series

### DIFF
--- a/app/styles/search-results-item.scss
+++ b/app/styles/search-results-item.scss
@@ -21,6 +21,7 @@
   display: flex;
   flex-direction: column;
   padding: 1em 1em 2em;
+  z-index: 1;
 
   /* align first series result box with images in other results */
   margin-top: 15px;


### PR DESCRIPTION
after: 
![image](https://user-images.githubusercontent.com/17847632/115255017-2c602c80-a12e-11eb-9f7c-6f483ae6221b.png)

før:
https://trello.com/c/kFJWx1WZ/70-filtermenu-kolliderer-med-billeder-i-serier