### PR TITLE
Add left/right arrows and keyboad navigation to assets accessed through series

### DIFF
--- a/app/styles/series-page.scss
+++ b/app/styles/series-page.scss
@@ -1,19 +1,21 @@
 .document-content {
+  position: relative;
   padding: 1rem 0 2rem;
   padding-top: $topbar-height;
 
   @media (min-width: $medium-size) {
     padding-top: $topbar-height * 3 / 2;
   }
+}
 
-  &--black {
-    background: black;
-    color: white;
-  }
-  &--dark-grey {
-    background: rgb(34, 34, 34);
-    color: white;
-  }
+.document-content--black {
+  background: black;
+  color: white;
+}
+
+.document-content--dark-grey {
+  background: rgb(34, 34, 34);
+  color: white;
 }
 
 .document-content__info {

--- a/app/views/series.pug
+++ b/app/views/series.pug
@@ -38,6 +38,8 @@ block content
               each tag in series.tags
                 .btn-group
                   +tag(tag)
+    .hidden-xs.hidden-sm
+      include includes/navigator
   .let-it-grow.is-list-view#start-of-content
     include includes/filterbar
     section.search-results

--- a/app/views/series.pug
+++ b/app/views/series.pug
@@ -8,7 +8,9 @@ prepend header
   +meta(`${series.title} - Billedserie`, series.description)
 
 block content
-  .document-content.document-content--black
+  .document-content.document-content--black(
+      data-id=series.url
+    )
     .container-fluid.document
       .row
         .document-content__preview.col-xs-12.col-md-7.col-md-push-5

--- a/collections-online/app/scripts-browserify/search/series.js
+++ b/collections-online/app/scripts-browserify/search/series.js
@@ -244,6 +244,7 @@ function initialize() {
             type: hit._type,
             metadata: hit._source
           };
+          item.metadata.isSeries = true;
           const markup = templates.searchResultItem(item);
           $results.append(markup);
           resultsLoaded.push(item);
@@ -251,7 +252,7 @@ function initialize() {
 
         navigator.save({
           resultsLoaded, queryBody
-        });
+        }, true);
 
         // Show some text if we don't have any results
         if (resultsTotal === 0) {

--- a/collections-online/app/scripts-browserify/search/series.js
+++ b/collections-online/app/scripts-browserify/search/series.js
@@ -13,6 +13,7 @@ const elasticsearchAggregationsBody = require('./es-aggregations-body');
 const resultsHeader = require('./results-header');
 const sorting = require('./sorting');
 const DEFAULT_SORTING = require('./default-sorting');
+const navigator = require('../document/navigator');
 
 const templates = {
   searchResultItem: require('views/includes/search-results-item')
@@ -246,6 +247,10 @@ function initialize() {
           const markup = templates.searchResultItem(item);
           $results.append(markup);
           resultsLoaded.push(item);
+        });
+
+        navigator.save({
+          resultsLoaded, queryBody
         });
 
         // Show some text if we don't have any results

--- a/collections-online/app/styles/document.scss
+++ b/collections-online/app/styles/document.scss
@@ -155,6 +155,7 @@
       opacity: 1;
       position: absolute;
       top: 50%;
+      z-index: 99;
       transform: translate(0, -50%);
       transition: $anim-duration-long;
 

--- a/collections-online/app/views/includes/search-results-item.pug
+++ b/collections-online/app/views/includes/search-results-item.pug
@@ -8,8 +8,9 @@ include ../mixins/icon
 - const altText = helpers.documentTitle(metadata) + (tagString ? ': ' + tagString : '');
 - const creationPeriod = helpers.getCreationPeriod(metadata);
 - const creationTime = helpers.getCreationTime(metadata);
+- const isSeries = helpers.getIsSeries(metadata);
 
-a.search-results-item.col-xs-6.col-sm-6.col-md-3.col-lg-2.col-xl-1(href=documentURL, target=target, class=type === 'series' ? 'search-results-item--black' : '')
+a.search-results-item.col-xs-6.col-sm-6.col-md-3.col-lg-2.col-xl-1(href=isSeries ? `${documentURL}?is-series=true` : documentURL, target=target, class=type === 'series' ? 'search-results-item--black' : '')
   .search-results-item__squared-container
     img(src=thumbnailURL alt=altText).search-results-item__squared-image.object-fit
     if mediaType === 'video'

--- a/collections-online/shared/helpers.js
+++ b/collections-online/shared/helpers.js
@@ -62,6 +62,13 @@ helpers.getDocumentURL = (metadata) => {
   return '/' + path.join('/');
 };
 
+helpers.getIsSeries = (metadata) => {
+  if(typeof metadata.isSeries == "undefined") {
+    return false;
+  }
+  return true;
+};
+
 helpers.getThumbnailURL = (metadata, size, watermarkPosition) => {
   if(metadata.file_format && metadata.file_format === 'MP3 Format') {
     return '../images/audio.jpg';


### PR DESCRIPTION
Until now, arrows have been missing from assets that you have accessed through a series. 
This should fix that. So you should now be able to make a search, find a series, select an asset in that series, and either use the left/right arrows with your mouse or with the arrow keys to go to the next/previous assets. 