### PR TITLE
Increase precision of period filter

### DIFF
--- a/collections-online/app/scripts-browserify/search/es-query-body.js
+++ b/collections-online/app/scripts-browserify/search/es-query-body.js
@@ -120,49 +120,49 @@ module.exports = function(parameters) {
               // Just return the single-field singlefieldRange.
               return singlefieldRange;
             }
-
-          } else if(filter.type === 'date-interval-range') {
-
-            if(!filter.fields || !filter.fields.from || !filter.fields.to) {
-              throw new Error('Expected filter to have fields.from and .to');
-            }
-            // We query based on the follwing rules:
-
-            // a | |       Excluded of as it's too old
-            // b       | | Excluded of as it's too new
-            // c   |   |   Included as the we are within the interval
-            // d     ||    Included as the interval is enclosed
-            // e |   |     Included as its not quarenteed that it's not too old
-            // f     |  |  Included as its not quarenteed that it's not too new
-            //      ^ ^
-            //      A B
-
-            const queries = [];
-            // If the user has selected a lower bound
-            if(range.gte) {
-              queries.push({
-                range: {
-                  [filter.fields.to]: {
-                    gte: range.gte,
-                  }
-                }
-              });
-            }
-            if(range.lt) {
-              queries.push({
-                range: {
-                  [filter.fields.from]: {
-                    lt: range.lt,
-                  }
-                }
-              });
-            }
-            return {
-              bool: {
-                must: queries
-              }
-            };
           }
+          //else if(filter.type === 'date-interval-range') {
+
+          //   if(!filter.fields || !filter.fields.from || !filter.fields.to) {
+          //     throw new Error('Expected filter to have fields.from and .to');
+          //   }
+          //   // We query based on the follwing rules:
+
+          //   // a | |       Excluded of as it's too old
+          //   // b       | | Excluded of as it's too new
+          //   // c   |   |   Included as the we are within the interval
+          //   // d     ||    Included as the interval is enclosed
+          //   // e |   |     Included as its not quarenteed that it's not too old
+          //   // f     |  |  Included as its not quarenteed that it's not too new
+          //   //      ^ ^
+          //   //      A B
+
+          //   const queries = [];
+          //   // If the user has selected a lower bound
+          //   if(range.gte) {
+          //     queries.push({
+          //       range: {
+          //         [filter.fields.to]: {
+          //           gte: range.gte,
+          //         }
+          //       }
+          //     });
+          //   }
+          //   if(range.lt) {
+          //     queries.push({
+          //       range: {
+          //         [filter.fields.from]: {
+          //           lt: range.lt,
+          //         }
+          //       }
+          //     });
+          //   }
+          //   return {
+          //     bool: {
+          //       must: queries
+          //     }
+          //   };
+          // }
         });
 
         queries.push({

--- a/collections-online/app/scripts-browserify/search/es-query-body.js
+++ b/collections-online/app/scripts-browserify/search/es-query-body.js
@@ -24,12 +24,12 @@ module.exports = function(parameters) {
         };
         query.terms[filter.field] = parameters.filters[field];
         queries.push(query);
-      } else if(filter.type === 'date-range' ||
-                filter.type === 'date-interval-range') {
-        var intervalQueries = parameters.filters[field].map(function(interval) {
+      } else if(filter.type === 'date-range' || filter.type === 'date-interval-range') {
+          var intervalQueries = parameters.filters[field].map(function(interval) {
           var intervalSplit = interval.split('-');
           var range = {
-            format: 'yyyy/MM/dd||yyy'
+            format: 'yyyy/MM/dd||yyy',
+            boost: 5
           };
           if(intervalSplit[0] && intervalSplit[0] !== '*') {
             range.gte = intervalSplit[0];
@@ -95,21 +95,21 @@ module.exports = function(parameters) {
               // Either the end of the range (range.gte) must fall between the
               // start and end of the period.
               periodFilter.bool.should[0].bool.must[0].range[filter.period.from] = {
-                lte: range.gte
+                gte: range.gte
               };
               // and after its end.
               periodFilter.bool.should[0].bool.must[1].range[filter.period.to] = {
-                gte: range.gte
+                lte: range.lte
               };
 
               // Or the end of the range must.
               periodFilter.bool.should[1].bool.must[0].range[filter.period.from] = {
-                lte: range.lt
+                gt: range.gt
               };
 
               // Year should be less than our to.
               periodFilter.bool.should[1].bool.must[1].range[filter.period.to] = {
-                gte: range.lt
+                lt: range.lt
               };
 
               // Should give us something like.

--- a/collections-online/app/scripts-browserify/search/es-query-body.js
+++ b/collections-online/app/scripts-browserify/search/es-query-body.js
@@ -28,8 +28,7 @@ module.exports = function(parameters) {
           var intervalQueries = parameters.filters[field].map(function(interval) {
           var intervalSplit = interval.split('-');
           var range = {
-            format: 'yyyy/MM/dd||yyy',
-            boost: 5
+            format: 'yyyy/MM/dd||yyy'
           };
           if(intervalSplit[0] && intervalSplit[0] !== '*') {
             range.gte = intervalSplit[0];
@@ -63,15 +62,23 @@ module.exports = function(parameters) {
 
               var periodFilter = {
                 bool: {
-                  should: [
+                  must: [
                     {
                       bool: {
                         must: [
                           {
-                            range: {}
+                            range: {
+                              [filter.period.from]: {
+                                gte: range.gte,
+                              }
+                            }
                           },
                           {
-                            range: {}
+                            range: { //TODO: is this even used?
+                              [filter.period.to]: {
+                                lte: range.lte,
+                              }
+                            }
                           }
                         ]
                       }
@@ -80,10 +87,18 @@ module.exports = function(parameters) {
                       bool: {
                         must: [
                           {
-                            range: {}
+                            range: { //TODO: is this even used?
+                              [filter.period.from]: {
+                                gt: range.gt,
+                              }
+                            }
                           },
                           {
-                            range: {}
+                            range: {
+                              [filter.period.to]: {
+                                lt: range.lt,
+                              }
+                            }
                           }
                         ]
                       }
@@ -91,74 +106,6 @@ module.exports = function(parameters) {
                   ]
                 }
               };
-
-              // Either the end of the range (range.gte) must fall between the
-              // start and end of the period.
-              periodFilter.bool.should[0].bool.must[0].range[filter.period.from] = {
-                gte: range.gte
-              };
-              // and after its end.
-              periodFilter.bool.should[0].bool.must[1].range[filter.period.to] = {
-                lte: range.lte
-              };
-
-              // Or the end of the range must.
-              periodFilter.bool.should[1].bool.must[0].range[filter.period.from] = {
-                gt: range.gt
-              };
-
-              // Year should be less than our to.
-              periodFilter.bool.should[1].bool.must[1].range[filter.period.to] = {
-                lt: range.lt
-              };
-
-              // Should give us something like.
-              //   bool: {
-              //     should: [
-              //       {
-              //         bool: {
-              //           must: [
-              //             {
-              //               range: {
-              //                 'creation_time_from.year': {
-              //                   lt: 1950
-              //                 }
-              //               }
-              //             },
-              //             {
-              //               range: {
-              //                 'creation_time_to.year': {
-              //                   gte: 1940
-              //                 }
-              //               }
-              //             }
-              //           ]
-              //         }
-              //       },
-              //       {
-              //         bool: {
-              //           must: [
-              //             {
-              //               range: {
-              //                 'creation_time_from.year': {
-              //                   lt: 1950
-              //                 }
-              //               }
-              //             },
-              //             {
-              //               range: {
-              //                 'creation_time_to.year': {
-              //                   gte: 1940
-              //                 }
-              //               }
-              //             }
-              //           ]
-              //         }
-              //       }
-              //     ]
-              //   }
-              // }
-              //
 
               // Setup a new combined filter that allows the asset to match
               // either a specific creation date or a period.
@@ -190,29 +137,25 @@ module.exports = function(parameters) {
             //      ^ ^
             //      A B
 
-            var queries = [];
+            const queries = [];
             // If the user has selected a lower bound
             if(range.gte) {
-              var tooOldQuery = {
-                range: {}
-              };
-              // It must be the case that the documents interval's to date is
-              // after the selected lower bound
-              tooOldQuery.range[filter.fields.to] = {
-                gte: range.gte
-              };
-              queries.push(tooOldQuery);
+              queries.push({
+                range: {
+                  [filter.fields.to]: {
+                    gte: range.gte,
+                  }
+                }
+              });
             }
             if(range.lt) {
-              var tooNewQuery = {
-                range: {}
-              };
-              // It must be the case that the documents interval's from date is
-              // before the selected upper bound
-              tooNewQuery.range[filter.fields.from] = {
-                lt: range.lt
-              };
-              queries.push(tooNewQuery);
+              queries.push({
+                range: {
+                  [filter.fields.from]: {
+                    lt: range.lt,
+                  }
+                }
+              });
             }
             return {
               bool: {


### PR DESCRIPTION
This PR should increase the precision of time periods filters so that when some selects a 10 year date range, they are presented with those 10 years and not images from the +50 years on either side. 