### PR TITLE
Setup general accesskey via env variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,11 @@ jobs:
           if [ "$CIRCLE_BRANCH" = "master" ]; then
             echo "NODE_ENV=beta" >> .env
             echo "AUTH0_CLIENT_SECRET=${AUTH0_CLIENT_SECRET_BETA}" >> .env
-            echo "REINDEX_ACCESS_KEY_BETA=${REINDEX_ACCESS_KEY_BETA}" >> .env
+            echo "KBH_ACCESS_KEY=${KBH_ACCESS_KEY}" >> .env
           elif [ "$CIRCLE_BRANCH" = "production" ]; then
             echo "NODE_ENV=production" >> .env
             echo "AUTH0_CLIENT_SECRET=${AUTH0_CLIENT_SECRET_PRODUCTION}" >> .env
+            echo "KBH_ACCESS_KEY=${KBH_ACCESS_KEY}" >> .env
           else
             echo "Unexpected branch ($CIRCLE_BRANCH), could not determine NODE_ENV" && exit 1;
           fi

--- a/config/env/base.js
+++ b/config/env/base.js
@@ -160,7 +160,7 @@ let config = {
   },
   port: process.env.PORT || 9000,
   projectOxfordAPIKey: process.env.PROJECT_OXFORD_API_KEY,
-  reindexAccessKey: process.env.REINDEX_ACCESS_KEY || 'adelgade',
+  reindexAccessKey: process.env.KBH_ACCESS_KEY || 'adelgade',
   search: {
     baseQuery: {
       'bool': {

--- a/config/env/base.js
+++ b/config/env/base.js
@@ -160,7 +160,7 @@ let config = {
   },
   port: process.env.PORT || 9000,
   projectOxfordAPIKey: process.env.PROJECT_OXFORD_API_KEY,
-  reindexAccessKey: process.env.KBH_ACCESS_KEY || 'adelgade',
+  kbhAccessKey: process.env.KBH_ACCESS_KEY,
   search: {
     baseQuery: {
       'bool': {

--- a/config/env/beta.js
+++ b/config/env/beta.js
@@ -24,7 +24,7 @@ const beta = _.merge({}, base, {
     sitewidePassword: true,
     users: true
   },
-  reindexAccessKey: process.env.REINDEX_ACCESS_KEY_BETA,
+  reindexAccessKey: process.env.KBH_ACCESS_KEY,
   host: 'beta.kbhbilleder.dk',
   enforceHttps: true,
   ip: null,

--- a/config/env/beta.js
+++ b/config/env/beta.js
@@ -24,7 +24,7 @@ const beta = _.merge({}, base, {
     sitewidePassword: true,
     users: true
   },
-  reindexAccessKey: process.env.KBH_ACCESS_KEY,
+  kbhAccessKey: process.env.KBH_ACCESS_KEY,
   host: 'beta.kbhbilleder.dk',
   enforceHttps: true,
   ip: null,

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -16,7 +16,7 @@ const development = _.merge({}, base, {
       logRequests: true
     }
   },
-  reindexAccessKey: process.env.REINDEX_ACCESS_KEY_DEVELOPMENT,
+  kbhAccessKey: process.env.KBH_ACCESS_KEY,
   siteTitle: 'kbhbilleder.dk (dev)',
   allowRobots: true,
   es: {

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -30,7 +30,7 @@ const production = _.merge({}, base, {
     analyticsPropertyID: 'UA-78446616-1'
   },
   host: 'kbhbilleder.dk',
-  reindexAccessKey: process.env.KBH_ACCESS_KEY,
+  kbhAccessKey: process.env.KBH_ACCESS_KEY,
   enforceHttps: true,
   ip: null,
   port: null,

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -30,7 +30,7 @@ const production = _.merge({}, base, {
     analyticsPropertyID: 'UA-78446616-1'
   },
   host: 'kbhbilleder.dk',
-  // reindexAccessKey: process.env.REINDEX_ACCESS_KEY_PROD,
+  reindexAccessKey: process.env.KBH_ACCESS_KEY,
   enforceHttps: true,
   ip: null,
   port: null,

--- a/controllers/indexing.js
+++ b/controllers/indexing.js
@@ -170,6 +170,10 @@ function deleteAsset(catalogAlias, assetId) {
 }
 
 module.exports.asset = function(req, res, next) {
+  console.log("#######body", req.body);
+  if(req.body.apiKey !== config.kbhAccessKey) {
+    return res.sendStatus(401);
+  }
   const action = req.body.action || null;
   const catalogName = req.body.collection || null;
   let id = req.body.id || '';

--- a/plugins/indexing.js
+++ b/plugins/indexing.js
@@ -6,7 +6,7 @@ module.exports = {
   module: indexing,
   registerRoutes: app => {
     app.get('/index/recent', (req, res) => {
-      if (config.reindexAccessKey && req.query.accesskey !== config.reindexAccessKey) {
+      if (config.kbhAccessKey && req.query.accesskey !== config.kbhAccessKey) {
         res.status(401);
         return res.send('Accesskey required.');
       }
@@ -19,7 +19,7 @@ module.exports = {
       return res.send('Indexing of recent assets started.');
     });
     app.get('/index/all', (req, res) => {
-      if (config.reindexAccessKey && req.query.accesskey !== config.reindexAccessKey) {
+      if (config.kbhAccessKey && req.query.accesskey !== config.kbhAccessKey) {
         res.status(401);
         return res.send('Accesskey required.');
       }


### PR DESCRIPTION
We have now removed the hardcoded REINDEXING_ACCESS_KEY and replaced it with the more general KBH_ACCESS_KEY which is an environment variable set in Circle CI. 
Furthermore the access key is now used to gate secure '/index/all', '/index/recent' and '/index/asset' routes. This will minimize our exposure to malicious users.