### PR TITLE
increase timeout so large images can be downloaded

### DIFF
--- a/config/env/base.js
+++ b/config/env/base.js
@@ -66,7 +66,7 @@ let config = {
       trustSelfSigned: true
     },
     sessionRenewalRate: 30 * 60 * 1000, // Once every 30 minutes
-    timeout: 55000
+    timeout: 80000
   },
   email: {
     baseUrl: '@api.eu.mailgun.net/v3/mg.kbhbilleder.dk',


### PR DESCRIPTION
Det her billede timer out når man downloader det i prod: https://kbhbilleder.dk/kbh-arkiv/90927. 
Her har jeg øget timeout tiden med 30 sekunder for at se om det hjælper på det. 