### PR TITLE
enable asset id search

### DIFF
--- a/collections-online/app/scripts-browserify/search/es-query-body.js
+++ b/collections-online/app/scripts-browserify/search/es-query-body.js
@@ -181,6 +181,8 @@ module.exports = function(parameters) {
                 'short_title^5',
                 'description',
                 'previewAssets.short_title^3',
+                '_id',
+                'id',
                 'previewAssets.description',
                 'previewAssets.tags',
                 'catalog_name',


### PR DESCRIPTION
Allows search for asset id numbers. 
They are only unique for their catalog, so we might see one asset per catalog. 
Test search: 14003
Should show 2 assets: "Magasins julemand og Magasin elev" og "Fuglebakkevej"
Toggl: https://trello.com/c/T7dQ7fRt/76-s%C3%B8gning-p%C3%A5-id