### PR TITLE
Test update kbh access key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,21 @@ jobs:
             IMAGE_PATH=eu.gcr.io/${GOOGLE_PROJECT_ID}/frontend:$CIRCLE_BRANCH-$CIRCLE_SHA1-$CIRCLE_BUILD_NUM NAMESPACE=production deployment/set-deployment-image.sh
           fi
 
+  update-kbh-access-key:
+    docker:
+      - image: google/cloud-sdk
+    steps:
+      - run: |
+          echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > gcloud-service-key.json
+          set -x
+          gcloud auth activate-service-account --key-file gcloud-service-key.json
+          gcloud --quiet config set project $GOOGLE_PROJECT_ID
+          gcloud --quiet config set compute/zone $GOOGLE_COMPUTE_ZONE
+          gcloud --quiet container clusters get-credentials $GOOGLE_CLUSTER_NAME
+
+          kubectl -n beta set env deployment/cron KBH_ACCESS_KEY=$KBH_ACCESS_KEY
+          kubectl -n production set env deployment/cron KBH_ACCESS_KEY=$KBH_ACCESS_KEY
+
 workflows:
   version: 2
   build:
@@ -84,4 +99,9 @@ workflows:
             branches:
               only:
                 - master
+                - production
+      - update-kbh-access-key:
+          filters:
+            branches:
+              only:
                 - production

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,3 +1,9 @@
+# Notice!
+
+These scripts are not run via Circle CI - they are intended for execution from your local machine.
+- ath88
+
+
 # Deployment
 
 The app is currently deployed on the Google Cloud using the Google Container

--- a/deployment/cron-deployment.yaml
+++ b/deployment/cron-deployment.yaml
@@ -1,3 +1,6 @@
+# template is outdated - don't use this to update the cron deployment!
+# - ath88
+
 apiVersion: v1
 kind: Template
 objects:
@@ -18,6 +21,8 @@ objects:
             imagePullPolicy: Always
             resources: {}
             env:
+            - name: KBH_ACCESS_KEY
+              value: NOT-THE-ACTUAL-KEY
             - name: JOB_NAME1
               value: "Incremental"
             - name: JOB_COMMAND1


### PR DESCRIPTION
Toggl: CI på secrets til cron services

Nu kan man med et CI-job opdatere en dependent environment variabel i de to cron-deployments. Det trigger et redeploy, så de fremover bruger den nye variabel.

Når den skal ændres skal man altså manuelt trigger jobbet efter man har indsat den nye nøgle - der er ikke nogen måde at få et build triggered ved at ændre en environment variabel.