### PR TITLE
Large series fix

### DIFF
--- a/assets-pipeline/app/scripts-browserify/search/series.js
+++ b/assets-pipeline/app/scripts-browserify/search/series.js
@@ -46,22 +46,7 @@ let es = new elasticsearch.Client({
 let seriesAssetsFilter;
 
 function initialize() {
-  // Prepare series assets filter for this series, used to limit queries
-  // If there are a lot of assets in the query, elasticsearch breaks if
-  // they are in a single list -- so we chunk them.
-  if(window.__seriesAssets.length < 15) {
-    seriesAssetsFilter = {terms: {_id: window.__seriesAssets}};
-  }
-  else {
-    seriesAssetsFilter = {
-      bool: {
-        should: _.chunk(window.__seriesAssets, 15)
-          .map((chunk) => {
-            return {terms: {_id: chunk}};
-          }),
-      },
-    };
-  }
+  seriesAssetsFilter = {term: {series_ids: window.__seriesId}};
 
   const $results = $('#results');
   // Button shown at the end of the list search result that triggers the load
@@ -562,7 +547,7 @@ function initialize() {
 
 // If we know of series assets, load 'er up
 $(() => {
-  if(window.__seriesAssets) {
+  if(window.__seriesId) {
     initialize();
   }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kbh-billeder",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kbh-billeder",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Configuration/setup for the kbhbilleder.dk webapp built on top of Collections Online",
   "scripts": {
     "start": "concurrently \"npm run start:build:watch\" \"npm run start:server:watch\"",

--- a/shared/views/series.pug
+++ b/shared/views/series.pug
@@ -4,7 +4,7 @@ include ./mixins/meta
 include ./mixins/loader
 
 prepend header
-  script!=`window.__seriesAssets = JSON.parse('${JSON.stringify(series.assets)}');`
+  script!=`window.__seriesId = '${series.id}';`
   +meta(`${series.title} - Billedserie`, series.description)
 
 block content

--- a/webapplication/indexing/processing/result.js
+++ b/webapplication/indexing/processing/result.js
@@ -285,17 +285,18 @@ function processResultPage(totalcount, context, seriesLookup, mode, pageIndex) {
     }).then(({assets, assetSeries, errors}) => {
       // Create a list of items for a bulk call, for assets that are not errors.
       const items = [];
-      assets.filter(asset => !(asset instanceof AssetIndexingError))
-      .forEach(({metadata, context}) => {
-        items.push({
-          'index' : {
-            '_index': context.index,
-            '_type': 'asset',
-            '_id': metadata.collection + '-' + metadata.id
-          }
+      assets
+        .filter(asset => !(asset instanceof AssetIndexingError))
+        .forEach(({metadata, context}) => {
+          items.push({
+            'index' : {
+              '_index': context.index,
+              '_type': 'asset',
+              '_id': metadata.collection + '-' + metadata.id,
+            }
+          });
+          items.push(metadata);
         });
-        items.push(metadata);
-      });
 
       assetSeries.forEach((series) => {
         if(series.assets.length > 0) {

--- a/webapplication/indexing/processing/result.js
+++ b/webapplication/indexing/processing/result.js
@@ -219,6 +219,10 @@ function processResultPage(totalcount, context, seriesLookup, mode, pageIndex) {
     })
     .then(({assets, errors, seriesLookup}) => {
       assets.forEach(({ metadata, assetSeries }) => {
+        // Make series ids attached to assets so we can look it up
+        metadata.series_ids = assetSeries.map((series) => series._id);
+
+        // Set up series
         assetSeries.forEach((as) => {
           const series = seriesLookup[as._id];
           if(typeof series.assets == "undefined") {

--- a/webapplication/lib/controllers/series.js
+++ b/webapplication/lib/controllers/series.js
@@ -12,7 +12,10 @@ module.exports.get = (req, res, next) => {
     .then((seriesDoc) => {
       res.render('series.pug', {
         req,
-        series: seriesDoc._source,
+        series: {
+          id: seriesDoc._id.slice('series/'.length),
+          ...seriesDoc._source,
+        },
       });
     })
     .catch((error) => {


### PR DESCRIPTION
This fixes huge series (6k assets) by changing how we look up assets in series'.

We originally assumed that series would be pretty small, but they are not. So now we add a series_ids field (a list of ids) to all assets at index time, and query for this key inside series.